### PR TITLE
Split role schemas into small modules, exclude unused Hasura plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,23 @@ templates
 ```
 
 The keys don't have to exist on the object you call the template for, but any keys that do match will be replaced with the template value.
+
+## Split schema modules
+
+By default each role schema is generated as one module, which for large Hasura
+schemas can reach tens of thousands of lines and dominates PureScript compile
+times (a single module cannot be compiled in parallel, and any schema change
+recompiles all of it).
+
+Setting `split_schema_modules: true` in the workspace config yaml splits each
+role schema into many small modules instead. Only types in the same
+strongly-connected component of the type reference graph need to share a
+module (PureScript forbids cyclic imports); everything else is chunked by
+topological level. The top `Schema.{role}` module re-exports every chunk, so
+consuming code needs no changes.
+
+```yaml
+split_schema_modules: true
+# optional, rough upper bound on lines per generated module (default 500)
+split_module_max_lines: 500
+```

--- a/README.md
+++ b/README.md
@@ -87,3 +87,19 @@ split_schema_modules: true
 # optional, rough upper bound on lines per generated module (default 500)
 split_module_max_lines: 500
 ```
+
+## Excluding unused schema plumbing
+
+`exclude_type_patterns` drops GraphQL types whose name contains any of the
+given substrings, along with every field that returns or takes them. Types
+left unreachable from the schema roots are pruned as well (split mode).
+Useful for Hasura plumbing nothing in the codebase queries:
+
+```yaml
+exclude_type_patterns:
+  - _stddev
+  - _var_pop
+  - _var_samp
+  - _variance
+  - _stream_cursor
+```

--- a/src/build_schema.rs
+++ b/src/build_schema.rs
@@ -136,6 +136,9 @@ pub async fn build_schema(
                 if obj.name.starts_with("__") {
                     continue;
                 }
+                if is_excluded(&obj.name, &workspace_config.exclude_type_patterns) {
+                    continue;
+                }
 
                 // Convert the hasura_type_name to a PurescriptTypeName
                 let name = pascal_case(&obj.name);
@@ -145,6 +148,16 @@ pub async fn build_schema(
 
                 // Add type fields to the record
                 for field in obj.fields.iter() {
+                    // Skip fields that return or take an excluded type
+                    // (e.g. the stddev field of aggregate_fields, or _stream
+                    // root fields whose cursor argument is excluded).
+                    if is_excluded(&field.ty.name, &workspace_config.exclude_type_patterns)
+                        || field.args.iter().any(|arg| {
+                            is_excluded(&arg.ty.name, &workspace_config.exclude_type_patterns)
+                        })
+                    {
+                        continue;
+                    }
                     // If the field has arguments then the purescript representation will be:
                     // field_name :: { | Arguments } -> ReturnType
 
@@ -220,6 +233,9 @@ pub async fn build_schema(
                 if en.name.starts_with("__") {
                     continue;
                 }
+                if is_excluded(&en.name, &workspace_config.exclude_type_patterns) {
+                    continue;
+                }
 
                 // Generate purescript enums for all graphql types
                 // These include table select columns as well as custom enums
@@ -235,6 +251,9 @@ pub async fn build_schema(
                 if obj.name.starts_with("__") {
                     continue;
                 }
+                if is_excluded(&obj.name, &workspace_config.exclude_type_patterns) {
+                    continue;
+                }
 
                 // Convert the hasura_type_name to a PurescriptTypeName
                 let name = pascal_case(&obj.name);
@@ -242,6 +261,10 @@ pub async fn build_schema(
                 // Build a purescript record with all fields
                 let mut record = PurescriptRecord::new("Query");
                 for field in obj.fields.iter() {
+                    // Skip fields typed by an excluded type
+                    if is_excluded(&field.ty.name, &workspace_config.exclude_type_patterns) {
+                        continue;
+                    }
                     // Work out the type of the field, wrapping in NotNull or Array as required.
                     // This will also resolve any outside types.
                     let arg_type = wrap_type(
@@ -327,9 +350,13 @@ pub async fn build_schema(
         );
     }
 
-    // Write the directives module
+    // Write the directives module.
+    // Awaited so the write is guaranteed to have happened (and be registered)
+    // before the stale-file cleanup at the end of the run.
     let path_clone = lib_path.clone();
-    spawn_blocking(move || build_directives(path_clone, directive_role, schema.directives));
+    spawn_blocking(move || build_directives(path_clone, directive_role, schema.directives))
+        .await
+        .expect("Failed to write directives module.");
 
     write(
         &format!("{lib_path}/spago.yaml"),
@@ -358,6 +385,12 @@ fn to_spago_yaml(prefix: &str, role: &str, imports: &Vec<PurescriptImport>) -> S
         spago_yaml.push_str(&format!("\n    - {name}"));
     }
     spago_yaml
+}
+
+/// Whether a GraphQL type name matches any of the configured exclusion
+/// patterns (plain substring match).
+fn is_excluded(gql_type_name: &str, patterns: &Vec<String>) -> bool {
+    patterns.iter().any(|p| gql_type_name.contains(p.as_str()))
 }
 
 /// Simplified import add via plain strings

--- a/src/build_schema.rs
+++ b/src/build_schema.rs
@@ -24,6 +24,7 @@ use crate::{
         purescript_record::{Field, PurescriptRecord},
         purescript_type::PurescriptType,
         purescript_variant::Variant,
+        split_modules::print_split_modules,
     },
     write::write,
 };
@@ -295,19 +296,36 @@ pub async fn build_schema(
         kebab_case(&role)
     );
 
-    // Write the schema module to the file system
-    let schema_module_path = format!("{lib_path}/src/Schema/{role}.purs");
-    write(
-        &schema_module_path,
-        &print_module(
+    // Write the schema module(s) to the file system
+    if workspace_config.split_schema_modules {
+        types.sort_by_key(|t| t.name.clone());
+        let modules = print_split_modules(
             &role,
-            &mut types,
-            &mut records,
-            &mut imports,
-            &mut variants,
-            &mut instances,
-        ),
-    );
+            &types,
+            &records,
+            &imports,
+            &variants,
+            &instances,
+            workspace_config.split_module_max_lines,
+        );
+        for (module_name, contents) in modules {
+            let module_path = module_name.replace('.', "/");
+            write(&format!("{lib_path}/src/{module_path}.purs"), &contents);
+        }
+    } else {
+        let schema_module_path = format!("{lib_path}/src/Schema/{role}.purs");
+        write(
+            &schema_module_path,
+            &print_module(
+                &role,
+                &mut types,
+                &mut records,
+                &mut imports,
+                &mut variants,
+                &mut instances,
+            ),
+        );
+    }
 
     // Write the directives module
     let path_clone = lib_path.clone();

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -47,6 +47,11 @@ pub struct WorkspaceConfig {
     /// Rough upper bound on lines per split module. Single cyclic type groups
     /// may exceed it.
     pub split_module_max_lines: usize,
+    /// GraphQL types whose name contains any of these substrings are not
+    /// generated, and fields returning or taking them are dropped. Used to
+    /// skip Hasura plumbing the codebase never queries (e.g. `_stddev`,
+    /// `_stream_cursor`).
+    pub exclude_type_patterns: Vec<String>,
 }
 
 impl WorkspaceConfig {
@@ -68,9 +73,24 @@ impl WorkspaceConfig {
             .get(&Yaml::String("split_module_max_lines".to_string()))
             .and_then(|v| v.as_i64())
             .unwrap_or(500) as usize;
+        let exclude_type_patterns = yaml_hash
+            .get(&Yaml::String("exclude_type_patterns".to_string()))
+            .and_then(|v| v.as_vec())
+            .map(|patterns| {
+                patterns
+                    .iter()
+                    .map(|p| {
+                        p.as_str()
+                            .expect("Workspace yaml exclude_type_patterns should all be strings")
+                            .to_string()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         Some(Self {
             split_schema_modules,
             split_module_max_lines,
+            exclude_type_patterns,
             postgres_enums_lib: postgres_enums_lib
                 .as_str()
                 .expect("Workspace yaml should contain postgres_enums_lib key.")

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -39,6 +39,14 @@ pub struct WorkspaceConfig {
     pub schema_libs_prefix: String,
     pub schema_libs_dir: String,
     pub variant_enums: Vec<String>,
+    /// Split each role schema into many small modules (grouped by
+    /// strongly-connected components of the type reference graph) instead of
+    /// one giant module. The top `Schema.{role}` module re-exports everything,
+    /// so consuming code is unaffected.
+    pub split_schema_modules: bool,
+    /// Rough upper bound on lines per split module. Single cyclic type groups
+    /// may exceed it.
+    pub split_module_max_lines: usize,
 }
 
 impl WorkspaceConfig {
@@ -52,7 +60,17 @@ impl WorkspaceConfig {
         let schema_libs_prefix = yaml_hash.get(&Yaml::String("schema_libs_prefix".to_string()))?;
         let schema_libs_dir = yaml_hash.get(&Yaml::String("schema_libs_dir".to_string()))?;
         let variant_enums = yaml_hash.get(&Yaml::String("variant_enums".to_string()));
+        let split_schema_modules = yaml_hash
+            .get(&Yaml::String("split_schema_modules".to_string()))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let split_module_max_lines = yaml_hash
+            .get(&Yaml::String("split_module_max_lines".to_string()))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(500) as usize;
         Some(Self {
+            split_schema_modules,
+            split_module_max_lines,
             postgres_enums_lib: postgres_enums_lib
                 .as_str()
                 .expect("Workspace yaml should contain postgres_enums_lib key.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use config::{
 use dotenv::dotenv;
 use enums::postgres_types::fetch_types;
 use tokio::spawn;
+use write::remove_stale_files;
 mod build_schema;
 mod config;
 mod enums;
@@ -31,15 +32,19 @@ async fn main() -> Result<()> {
     // Fetch the workspace config
     let workspace_config = parse_workspace().await?;
 
-    // Trash existing schema
-    for path in vec![
-        workspace_config.postgres_enums_dir.clone(),
-        workspace_config.shared_graphql_enums_dir.clone(),
-        workspace_config.schema_libs_dir.clone(),
-    ]
-    .iter()
-    {
-        remove_dir_all(path).ok();
+    // In split mode existing files are left in place so their mtimes survive
+    // when the content is unchanged; stale files are removed after generation
+    // instead (see the end of main). Otherwise trash the existing schema.
+    if !workspace_config.split_schema_modules {
+        for path in vec![
+            workspace_config.postgres_enums_dir.clone(),
+            workspace_config.shared_graphql_enums_dir.clone(),
+            workspace_config.schema_libs_dir.clone(),
+        ]
+        .iter()
+        {
+            remove_dir_all(path).ok();
+        }
     }
 
     // Generate postgres enum types
@@ -85,6 +90,19 @@ async fn main() -> Result<()> {
                 .expect("Failed to build schema gen task output")
                 .expect("Failed to join schema gen task output"),
         );
+    }
+
+    // Remove files left over from previous runs (renamed chunks, dropped
+    // types/roles). Only relevant in split mode; the other mode trashes the
+    // directories up front.
+    if workspace_config.split_schema_modules {
+        for dir in [
+            &workspace_config.postgres_enums_dir,
+            &workspace_config.shared_graphql_enums_dir,
+            &workspace_config.schema_libs_dir,
+        ] {
+            remove_stale_files(dir);
+        }
     }
 
     println!(

--- a/src/purescript_gen.rs
+++ b/src/purescript_gen.rs
@@ -6,3 +6,4 @@ pub mod purescript_print_module;
 pub mod purescript_record;
 pub mod purescript_type;
 pub mod purescript_variant;
+pub mod split_modules;

--- a/src/purescript_gen/purescript_instance.rs
+++ b/src/purescript_gen/purescript_instance.rs
@@ -22,6 +22,10 @@ impl DeriveInstance {
         self
     }
 
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
     pub fn to_string(&self) -> String {
         format!(
             "derive instance {} {} {}",

--- a/src/purescript_gen/purescript_variant.rs
+++ b/src/purescript_gen/purescript_variant.rs
@@ -16,6 +16,10 @@ impl Variant {
         self
     }
 
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     pub fn to_string(&self) -> String {
         let values = self
             .values

--- a/src/purescript_gen/split_modules.rs
+++ b/src/purescript_gen/split_modules.rs
@@ -1,0 +1,461 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use super::{
+    purescript_import::PurescriptImport, purescript_instance::DeriveInstance,
+    purescript_record::PurescriptRecord, purescript_type::PurescriptType,
+    purescript_variant::Variant,
+};
+
+/// Splits a role schema into many small modules instead of one giant one.
+///
+/// PureScript forbids cyclic imports, but only types in the same
+/// strongly-connected component of the reference graph actually need to share
+/// a module. Everything else is grouped into chunks by topological level
+/// (a declaration only ever references declarations on strictly lower levels,
+/// so modules within a level never import each other) and the top module
+/// re-exports the lot, keeping the public API identical to the unsplit output.
+///
+/// Returns (module_name, module_contents) pairs, top module included.
+pub fn print_split_modules(
+    role: &str,
+    types: &Vec<PurescriptType>,
+    schema_records: &Vec<PurescriptRecord>,
+    imports: &Vec<PurescriptImport>,
+    variants: &Vec<Variant>,
+    instances: &Vec<DeriveInstance>,
+    max_chunk_lines: usize,
+) -> Vec<(String, String)> {
+    // Instances (only newtype derives today) must live in the same module as
+    // the type they are derived for.
+    let mut instances_by_type: HashMap<&str, Vec<String>> = HashMap::new();
+    for instance in instances {
+        instances_by_type
+            .entry(instance.type_name())
+            .or_default()
+            .push(instance.to_string());
+    }
+
+    // Collect every declaration with its printed body and referenced tokens
+    let mut decls: Vec<Decl> = vec![];
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut add_decl = |name: &str, mut body: String| {
+        if !seen.insert(name.to_string()) {
+            return;
+        }
+        if let Some(instance_strs) = instances_by_type.get(name) {
+            for i in instance_strs {
+                body.push_str("\n");
+                body.push_str(i);
+            }
+        }
+        decls.push(Decl::new(name, body));
+    };
+    for t in types {
+        add_decl(&t.name, t.to_string());
+    }
+    for v in variants {
+        add_decl(v.name(), v.to_string());
+    }
+    decls.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let index_of: HashMap<String, usize> = decls
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d.name.clone(), i))
+        .collect();
+
+    // Reference graph between the declarations of this schema
+    let graph: Vec<Vec<usize>> = decls
+        .iter()
+        .map(|d| {
+            let mut refs: Vec<usize> = d
+                .tokens
+                .iter()
+                .filter_map(|t| index_of.get(t))
+                .copied()
+                .collect();
+            refs.sort();
+            refs.dedup();
+            refs
+        })
+        .collect();
+
+    let components = strongly_connected_components(&graph);
+    let levels = component_levels(&graph, &components);
+
+    // Group the components by level, then greedily pack each level into
+    // chunks of roughly max_chunk_lines. Modules on the same level never
+    // reference one another, so any grouping within a level is import-safe.
+    let max_level = levels.iter().copied().max().unwrap_or(0);
+    let mut chunks: Vec<Vec<usize>> = vec![]; // decl indices per chunk
+    for level in 0..=max_level {
+        let mut level_components: Vec<Vec<usize>> = components
+            .iter()
+            .zip(levels.iter())
+            .filter(|(_, l)| **l == level)
+            .map(|(c, _)| {
+                let mut c = c.clone();
+                c.sort_by(|a, b| decls[*a].name.cmp(&decls[*b].name));
+                c
+            })
+            .collect();
+        level_components.sort_by(|a, b| decls[a[0]].name.cmp(&decls[b[0]].name));
+
+        let mut chunk: Vec<usize> = vec![];
+        let mut chunk_lines = 0;
+        for component in level_components {
+            let component_lines: usize = component.iter().map(|i| decls[*i].lines).sum();
+            if !chunk.is_empty() && chunk_lines + component_lines > max_chunk_lines {
+                chunks.push(std::mem::take(&mut chunk));
+                chunk_lines = 0;
+            }
+            chunk.extend(component);
+            chunk_lines += component_lines;
+        }
+        if !chunk.is_empty() {
+            chunks.push(chunk);
+        }
+    }
+
+    // Name each chunk module after its alphabetically first declaration.
+    // Chunks partition the declarations, so the names are unique and remain
+    // stable under small schema changes.
+    let chunk_names: Vec<String> = chunks
+        .iter()
+        .map(|c| {
+            let first = c
+                .iter()
+                .map(|i| &decls[*i].name)
+                .min()
+                .expect("Chunks are never empty");
+            format!("Schema.{role}.{first}")
+        })
+        .collect();
+    let mut chunk_of: HashMap<usize, usize> = HashMap::new();
+    for (chunk_id, chunk) in chunks.iter().enumerate() {
+        for i in chunk {
+            chunk_of.insert(*i, chunk_id);
+        }
+    }
+
+    let merged_imports = PurescriptImport::merge(imports);
+    let mut modules: Vec<(String, String)> = vec![];
+
+    for (chunk_id, chunk) in chunks.iter().enumerate() {
+        let mut decl_indices = chunk.clone();
+        decl_indices.sort_by(|a, b| decls[*a].name.cmp(&decls[*b].name));
+
+        let mut tokens: HashSet<String> = HashSet::new();
+        for i in &decl_indices {
+            tokens.extend(decls[*i].tokens.iter().cloned());
+        }
+
+        // Imports of other generated chunk modules
+        let mut internal: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+        for i in &decl_indices {
+            for r in &graph[*i] {
+                let target_chunk = chunk_of[r];
+                if target_chunk != chunk_id {
+                    internal
+                        .entry(&chunk_names[target_chunk])
+                        .or_default()
+                        .insert(&decls[*r].name);
+                }
+            }
+        }
+
+        let mut import_lines = filter_external_imports(&merged_imports, &tokens);
+        for (module, names) in internal {
+            let names = names.into_iter().collect::<Vec<&str>>().join(", ");
+            import_lines.push(format!("import {module} ({names})"));
+        }
+        import_lines.sort();
+
+        let bodies = decl_indices
+            .iter()
+            .map(|i| decls[*i].body.clone())
+            .collect::<Vec<String>>()
+            .join("\n\n");
+
+        modules.push((
+            chunk_names[chunk_id].clone(),
+            format!(
+                "-- @generated\nmodule {} where\n\n{}\n\n{}\n",
+                chunk_names[chunk_id],
+                import_lines.join("\n"),
+                bodies
+            ),
+        ));
+    }
+
+    modules.push(top_module(
+        role,
+        schema_records,
+        &merged_imports,
+        &chunk_names,
+        &index_of,
+        &decls,
+        &chunk_of,
+    ));
+
+    modules
+}
+
+/// The top module keeps the original `Schema.{role}` name and public API:
+/// it re-exports every chunk module and declares the Schema record itself.
+fn top_module(
+    role: &str,
+    schema_records: &Vec<PurescriptRecord>,
+    merged_imports: &Vec<PurescriptImport>,
+    chunk_names: &Vec<String>,
+    index_of: &HashMap<String, usize>,
+    decls: &Vec<Decl>,
+    chunk_of: &HashMap<usize, usize>,
+) -> (String, String) {
+    let record_bodies = schema_records
+        .iter()
+        .map(|r| r.to_string())
+        .collect::<Vec<String>>()
+        .join("\n\n");
+    let tokens = tokenize(&record_bodies);
+
+    // Unqualified imports for the generated types the Schema record refers to
+    let mut internal: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for token in &tokens {
+        if let Some(i) = index_of.get(token) {
+            internal
+                .entry(&chunk_names[chunk_of[i]])
+                .or_default()
+                .insert(&decls[*i].name);
+        }
+    }
+
+    let mut import_lines = filter_external_imports(merged_imports, &tokens);
+    for (module, names) in internal {
+        let names = names.into_iter().collect::<Vec<&str>>().join(", ");
+        import_lines.push(format!("import {module} ({names})"));
+    }
+    for chunk_name in chunk_names {
+        import_lines.push(format!("import {chunk_name} as Export"));
+    }
+    import_lines.sort();
+
+    let exports = schema_records
+        .iter()
+        .map(|r| format!("\n  , {}", r.name))
+        .collect::<String>();
+
+    let module_name = format!("Schema.{role}");
+    let contents = format!(
+        "-- @generated\nmodule {module_name}\n  ( module Export{exports}\n  ) where\n\n{}\n\n{record_bodies}\n",
+        import_lines.join("\n"),
+    );
+    (module_name, contents)
+}
+
+/// Keep only the imports whose specified names actually occur in the module
+/// body, dropping import lines that end up empty.
+fn filter_external_imports(
+    merged: &Vec<PurescriptImport>,
+    tokens: &HashSet<String>,
+) -> Vec<String> {
+    let mut lines: Vec<String> = vec![];
+    for import in merged {
+        let mut import = import.clone();
+        // Special case kept identical to print_module: these two modules are
+        // always imported by their head type only.
+        if import.module == "GraphQL.Hasura.ComparisonExp" {
+            import.specified = vec![];
+            import.add_specified_mut("ComparisonExp");
+        } else if import.module == "Data.ComparisonExpString" {
+            import.specified = vec![];
+            import.add_specified_mut("ComparisonExpString");
+        }
+        import.specified.retain(|s| {
+            let bare = s
+                .import
+                .trim_start_matches("class ")
+                .trim_start_matches("type ");
+            tokens.contains(bare)
+        });
+        if import.specified.is_empty() {
+            continue;
+        }
+        lines.push(import.to_string());
+    }
+    lines.sort();
+    lines.dedup();
+    lines
+}
+
+struct Decl {
+    name: String,
+    body: String,
+    lines: usize,
+    tokens: HashSet<String>,
+}
+
+impl Decl {
+    fn new(name: &str, body: String) -> Self {
+        let mut tokens = tokenize(&body);
+        tokens.remove(name);
+        Decl {
+            name: name.to_string(),
+            lines: body.lines().count(),
+            tokens,
+            body,
+        }
+    }
+}
+
+/// All identifier-shaped tokens in a printed declaration. Type references
+/// always appear as standalone tokens, so this can never miss an edge; the
+/// occasional false positive from a string literal only makes the grouping
+/// slightly more conservative.
+fn tokenize(s: &str) -> HashSet<String> {
+    let mut tokens = HashSet::new();
+    let mut current = String::new();
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' || c == '\'' {
+            current.push(c);
+        } else if !current.is_empty() {
+            tokens.insert(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.insert(current);
+    }
+    tokens
+}
+
+/// Kosaraju's algorithm (iterative). Returns components in topological order:
+/// if any member of component A references a member of component B, then A
+/// comes before B in the result.
+fn strongly_connected_components(graph: &Vec<Vec<usize>>) -> Vec<Vec<usize>> {
+    let n = graph.len();
+
+    // First pass: record finish order via iterative DFS
+    let mut visited = vec![false; n];
+    let mut finish_order: Vec<usize> = Vec::with_capacity(n);
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+        visited[start] = true;
+        let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+        while let Some((node, edge)) = stack.last().copied() {
+            if edge < graph[node].len() {
+                stack.last_mut().expect("stack is non-empty").1 += 1;
+                let next = graph[node][edge];
+                if !visited[next] {
+                    visited[next] = true;
+                    stack.push((next, 0));
+                }
+            } else {
+                finish_order.push(node);
+                stack.pop();
+            }
+        }
+    }
+
+    // Second pass: DFS over the transposed graph in reverse finish order
+    let mut transposed: Vec<Vec<usize>> = vec![vec![]; n];
+    for (node, refs) in graph.iter().enumerate() {
+        for r in refs {
+            transposed[*r].push(node);
+        }
+    }
+    let mut component_of = vec![usize::MAX; n];
+    let mut components: Vec<Vec<usize>> = vec![];
+    for &start in finish_order.iter().rev() {
+        if component_of[start] != usize::MAX {
+            continue;
+        }
+        let id = components.len();
+        component_of[start] = id;
+        let mut members = vec![start];
+        let mut stack = vec![start];
+        while let Some(node) = stack.pop() {
+            for &next in &transposed[node] {
+                if component_of[next] == usize::MAX {
+                    component_of[next] = id;
+                    members.push(next);
+                    stack.push(next);
+                }
+            }
+        }
+        components.push(members);
+    }
+    components
+}
+
+/// Longest-path level of each component in the condensation DAG. Level 0
+/// components reference nothing outside themselves; every reference points to
+/// a strictly lower level.
+fn component_levels(graph: &Vec<Vec<usize>>, components: &Vec<Vec<usize>>) -> Vec<usize> {
+    let mut component_of = vec![usize::MAX; graph.len()];
+    for (id, members) in components.iter().enumerate() {
+        for m in members {
+            component_of[*m] = id;
+        }
+    }
+    // Components arrive in topological order (references point to higher
+    // ids), so one reverse sweep resolves all levels.
+    let mut levels = vec![0usize; components.len()];
+    for id in (0..components.len()).rev() {
+        let mut level = 0;
+        for member in &components[id] {
+            for r in &graph[*member] {
+                let target = component_of[*r];
+                if target != id {
+                    level = level.max(levels[target] + 1);
+                }
+            }
+        }
+        levels[id] = level;
+    }
+    levels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sccs_and_levels() {
+        // 0 <-> 1 form a cycle, 2 depends on the cycle, 3 is independent
+        let graph = vec![vec![1], vec![0], vec![0], vec![]];
+        let components = strongly_connected_components(&graph);
+        let cycle = components
+            .iter()
+            .find(|c| c.len() == 2)
+            .expect("cycle component");
+        let mut cycle = cycle.clone();
+        cycle.sort();
+        assert_eq!(cycle, vec![0, 1]);
+
+        let levels = component_levels(&graph, &components);
+        let level_of = |node: usize| {
+            components
+                .iter()
+                .zip(levels.iter())
+                .find(|(c, _)| c.contains(&node))
+                .map(|(_, l)| *l)
+                .expect("node in some component")
+        };
+        assert_eq!(level_of(0), 0);
+        assert_eq!(level_of(1), 0);
+        assert_eq!(level_of(2), 1);
+        assert_eq!(level_of(3), 0);
+    }
+
+    #[test]
+    fn tokenizer_splits_identifiers() {
+        let tokens = tokenize("newtype A = A\n  { b :: AsGql \"x_exp\" (Maybe B) }");
+        assert!(tokens.contains("A"));
+        assert!(tokens.contains("B"));
+        assert!(tokens.contains("Maybe"));
+        assert!(tokens.contains("x_exp"));
+        assert!(!tokens.contains("A = A"));
+    }
+}

--- a/src/purescript_gen/split_modules.rs
+++ b/src/purescript_gen/split_modules.rs
@@ -58,27 +58,47 @@ pub fn print_split_modules(
     }
     decls.sort_by(|a, b| a.name.cmp(&b.name));
 
-    let index_of: HashMap<String, usize> = decls
-        .iter()
-        .enumerate()
-        .map(|(i, d)| (d.name.clone(), i))
-        .collect();
+    let mut index_of = build_index(&decls);
+    let mut graph = build_graph(&decls, &index_of);
 
-    // Reference graph between the declarations of this schema
-    let graph: Vec<Vec<usize>> = decls
+    // Prune declarations unreachable from the Schema record. This happens
+    // when exclude_type_patterns removed every field that referenced a helper
+    // type, or when the introspected schema carries genuinely orphaned types.
+    let record_tokens = tokenize(
+        &schema_records
+            .iter()
+            .map(|r| r.to_string())
+            .collect::<Vec<String>>()
+            .join("\n"),
+    );
+    let mut reachable = vec![false; decls.len()];
+    let mut queue: Vec<usize> = record_tokens
         .iter()
-        .map(|d| {
-            let mut refs: Vec<usize> = d
-                .tokens
-                .iter()
-                .filter_map(|t| index_of.get(t))
-                .copied()
-                .collect();
-            refs.sort();
-            refs.dedup();
-            refs
-        })
+        .filter_map(|t| index_of.get(t))
+        .copied()
         .collect();
+    for i in &queue {
+        reachable[*i] = true;
+    }
+    while let Some(i) = queue.pop() {
+        for r in &graph[i] {
+            if !reachable[*r] {
+                reachable[*r] = true;
+                queue.push(*r);
+            }
+        }
+    }
+    let pruned = reachable.iter().filter(|r| !**r).count();
+    if pruned > 0 {
+        println!("Pruned {pruned} types unreachable from the {role} schema");
+        decls = decls
+            .into_iter()
+            .zip(reachable)
+            .filter_map(|(d, r)| if r { Some(d) } else { None })
+            .collect();
+        index_of = build_index(&decls);
+        graph = build_graph(&decls, &index_of);
+    }
 
     let components = strongly_connected_components(&graph);
     let levels = component_levels(&graph, &components);
@@ -254,12 +274,14 @@ fn top_module(
 }
 
 /// Keep only the imports whose specified names actually occur in the module
-/// body, dropping import lines that end up empty.
+/// body, dropping import lines that end up empty. When two modules provide
+/// the same name (e.g. Time from both Data.Time and Data.DateTime via outside
+/// types) it is kept on one line only, avoiding redundant-import warnings.
 fn filter_external_imports(
     merged: &Vec<PurescriptImport>,
     tokens: &HashSet<String>,
 ) -> Vec<String> {
-    let mut lines: Vec<String> = vec![];
+    let mut kept: Vec<PurescriptImport> = vec![];
     for import in merged {
         let mut import = import.clone();
         // Special case kept identical to print_module: these two modules are
@@ -278,6 +300,15 @@ fn filter_external_imports(
                 .trim_start_matches("type ");
             tokens.contains(bare)
         });
+        kept.push(import);
+    }
+    kept.sort_by(|a, b| a.module.cmp(&b.module));
+    let mut seen_names: HashSet<String> = HashSet::new();
+    let mut lines: Vec<String> = vec![];
+    for mut import in kept {
+        import
+            .specified
+            .retain(|s| seen_names.insert(s.import.clone()));
         if import.specified.is_empty() {
             continue;
         }
@@ -308,15 +339,49 @@ impl Decl {
     }
 }
 
-/// All identifier-shaped tokens in a printed declaration. Type references
-/// always appear as standalone tokens, so this can never miss an edge; the
-/// occasional false positive from a string literal only makes the grouping
-/// slightly more conservative.
+fn build_index(decls: &Vec<Decl>) -> HashMap<String, usize> {
+    decls
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d.name.clone(), i))
+        .collect()
+}
+
+/// Reference graph between the declarations of this schema
+fn build_graph(decls: &Vec<Decl>, index_of: &HashMap<String, usize>) -> Vec<Vec<usize>> {
+    decls
+        .iter()
+        .map(|d| {
+            let mut refs: Vec<usize> = d
+                .tokens
+                .iter()
+                .filter_map(|t| index_of.get(t))
+                .copied()
+                .collect();
+            refs.sort();
+            refs.dedup();
+            refs
+        })
+        .collect()
+}
+
+/// All identifier-shaped tokens in a printed declaration, ignoring string
+/// literals (which hold GraphQL names, not PureScript references). Type
+/// references always appear as standalone tokens outside strings, so this
+/// can never miss an edge or an import.
 fn tokenize(s: &str) -> HashSet<String> {
     let mut tokens = HashSet::new();
     let mut current = String::new();
+    let mut in_string = false;
     for c in s.chars() {
-        if c.is_ascii_alphanumeric() || c == '_' || c == '\'' {
+        if c == '"' {
+            in_string = !in_string;
+            if !current.is_empty() {
+                tokens.insert(std::mem::take(&mut current));
+            }
+        } else if in_string {
+            continue;
+        } else if c.is_ascii_alphanumeric() || c == '_' || c == '\'' {
             current.push(c);
         } else if !current.is_empty() {
             tokens.insert(std::mem::take(&mut current));
@@ -450,12 +515,12 @@ mod tests {
     }
 
     #[test]
-    fn tokenizer_splits_identifiers() {
+    fn tokenizer_splits_identifiers_and_skips_strings() {
         let tokens = tokenize("newtype A = A\n  { b :: AsGql \"x_exp\" (Maybe B) }");
         assert!(tokens.contains("A"));
         assert!(tokens.contains("B"));
         assert!(tokens.contains("Maybe"));
-        assert!(tokens.contains("x_exp"));
+        assert!(!tokens.contains("x_exp"), "string literals are not references");
         assert!(!tokens.contains("A = A"));
     }
 }

--- a/src/purescript_gen/split_modules.rs
+++ b/src/purescript_gen/split_modules.rs
@@ -214,8 +214,6 @@ pub fn print_split_modules(
         &merged_imports,
         &chunk_names,
         &index_of,
-        &decls,
-        &chunk_of,
     ));
 
     modules
@@ -229,8 +227,6 @@ fn top_module(
     merged_imports: &Vec<PurescriptImport>,
     chunk_names: &Vec<String>,
     index_of: &HashMap<String, usize>,
-    decls: &Vec<Decl>,
-    chunk_of: &HashMap<usize, usize>,
 ) -> (String, String) {
     let record_bodies = schema_records
         .iter()
@@ -239,22 +235,12 @@ fn top_module(
         .join("\n\n");
     let tokens = tokenize(&record_bodies);
 
-    // Unqualified imports for the generated types the Schema record refers to
-    let mut internal: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-    for token in &tokens {
-        if let Some(i) = index_of.get(token) {
-            internal
-                .entry(&chunk_names[chunk_of[i]])
-                .or_default()
-                .insert(&decls[*i].name);
-        }
-    }
+    // Generated types the Schema record refers to are used through the Export
+    // qualifier: importing a chunk both explicitly and `as Export` would raise
+    // DuplicateSelectiveImport warnings.
+    let record_bodies = qualify_tokens(&record_bodies, "Export", index_of);
 
     let mut import_lines = filter_external_imports(merged_imports, &tokens);
-    for (module, names) in internal {
-        let names = names.into_iter().collect::<Vec<&str>>().join(", ");
-        import_lines.push(format!("import {module} ({names})"));
-    }
     for chunk_name in chunk_names {
         import_lines.push(format!("import {chunk_name} as Export"));
     }
@@ -337,6 +323,40 @@ impl Decl {
             body,
         }
     }
+}
+
+/// Prefix every token that names a generated declaration with a module
+/// qualifier, leaving string literals and other tokens untouched.
+fn qualify_tokens(s: &str, qualifier: &str, names: &HashMap<String, usize>) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut current = String::new();
+    let mut in_string = false;
+    let flush = |current: &mut String, out: &mut String| {
+        if !current.is_empty() {
+            if names.contains_key(current.as_str()) {
+                out.push_str(qualifier);
+                out.push('.');
+            }
+            out.push_str(current);
+            current.clear();
+        }
+    };
+    for c in s.chars() {
+        if c == '"' {
+            flush(&mut current, &mut out);
+            in_string = !in_string;
+            out.push(c);
+        } else if in_string {
+            out.push(c);
+        } else if c.is_ascii_alphanumeric() || c == '_' || c == '\'' {
+            current.push(c);
+        } else {
+            flush(&mut current, &mut out);
+            out.push(c);
+        }
+    }
+    flush(&mut current, &mut out);
+    out
 }
 
 fn build_index(decls: &Vec<Decl>) -> HashMap<String, usize> {
@@ -512,6 +532,19 @@ mod tests {
         assert_eq!(level_of(1), 0);
         assert_eq!(level_of(2), 1);
         assert_eq!(level_of(3), 0);
+    }
+
+    #[test]
+    fn qualifies_only_known_declaration_tokens() {
+        let names = HashMap::from([("Query".to_string(), 0), ("Mutation".to_string(), 1)]);
+        let out = qualify_tokens(
+            "type Schema =\n  { query :: Query\n  , directives :: Proxy Directives\n  , mutation :: Mutation\n  }",
+            "Export",
+            &names,
+        );
+        assert!(out.contains("query :: Export.Query"));
+        assert!(out.contains("mutation :: Export.Mutation"));
+        assert!(out.contains("Proxy Directives"), "external names untouched");
     }
 
     #[test]

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,8 +2,15 @@ use std::{fs, path::Path};
 
 pub fn write(path: &str, contents: &str) -> () {
     let file_name = Path::new(path);
+    // Leave identical files untouched so downstream tools (git, purs) see
+    // fewer changes.
+    if let Ok(existing) = fs::read_to_string(file_name) {
+        if existing == contents {
+            return;
+        }
+    }
     if let Some(p) = file_name.parent() {
         fs::create_dir_all(p).expect("Failed to create directory for new file.");
     };
-    fs::write(file_name, contents).expect(&format!("Failed to write file."));
+    fs::write(file_name, contents).expect(&format!("Failed to write file at {path}"));
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,16 +1,74 @@
-use std::{fs, path::Path};
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+
+/// Every file written during this run, canonicalized. Used by
+/// `remove_stale_files` to clean up files from previous runs without
+/// trashing whole directories (which would bump mtimes on unchanged files
+/// and force purs to re-hash everything).
+static WRITTEN: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
+fn written() -> &'static Mutex<HashSet<PathBuf>> {
+    WRITTEN.get_or_init(|| Mutex::new(HashSet::new()))
+}
 
 pub fn write(path: &str, contents: &str) -> () {
     let file_name = Path::new(path);
     // Leave identical files untouched so downstream tools (git, purs) see
     // fewer changes.
-    if let Ok(existing) = fs::read_to_string(file_name) {
-        if existing == contents {
-            return;
+    let unchanged = fs::read_to_string(file_name)
+        .map(|existing| existing == contents)
+        .unwrap_or(false);
+    if !unchanged {
+        if let Some(p) = file_name.parent() {
+            fs::create_dir_all(p).expect("Failed to create directory for new file.");
+        };
+        fs::write(file_name, contents).expect(&format!("Failed to write file at {path}"));
+    }
+    if let Ok(canonical) = fs::canonicalize(file_name) {
+        written()
+            .lock()
+            .expect("Write registry lock poisoned.")
+            .insert(canonical);
+    }
+}
+
+/// Delete generated-looking files (.purs, spago.yaml, .gitignore) under `dir`
+/// that were not written during this run, then prune directories left empty.
+/// Call after all generation has finished.
+pub fn remove_stale_files(dir: &str) {
+    let registry = written()
+        .lock()
+        .expect("Write registry lock poisoned.")
+        .clone();
+    remove_stale_in(Path::new(dir), &registry);
+}
+
+fn is_generated_file(path: &Path) -> bool {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    path.extension().map(|e| e == "purs").unwrap_or(false)
+        || name == "spago.yaml"
+        || name == ".gitignore"
+}
+
+fn remove_stale_in(dir: &Path, registry: &HashSet<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            remove_stale_in(&path, registry);
+            // remove_dir only succeeds on empty directories
+            fs::remove_dir(&path).ok();
+        } else if is_generated_file(&path) {
+            let canonical = fs::canonicalize(&path).unwrap_or(path.clone());
+            if !registry.contains(&canonical) {
+                fs::remove_file(&path).ok();
+            }
         }
     }
-    if let Some(p) = file_name.parent() {
-        fs::create_dir_all(p).expect("Failed to create directory for new file.");
-    };
-    fs::write(file_name, contents).expect(&format!("Failed to write file at {path}"));
 }


### PR DESCRIPTION
## What

Two opt-in workspace-config options aimed at PureScript compile times for the generated schemas, plus regen ergonomics fixes.

### `split_schema_modules: true`

Each role schema is generated as ~50–130 small modules instead of one giant one (AdminDashboard today: a single 59,526-line module). Only types in the same strongly-connected component of the type reference graph must share a module (PureScript forbids cyclic imports); everything else is chunked by topological level, so the module graph is provably acyclic. The top `Schema.{Role}` module re-exports every chunk — **consuming code needs no changes** (verified by compiling the smoke-tests lambda unmodified against the split output).

Regens also become incremental: files are only written when content changes, the output dirs are no longer wiped up front (a no-change regen touches zero files, preserving mtimes), and stale files from renamed chunks are swept afterwards. The directives write is now awaited instead of fire-and-forget.

### `exclude_type_patterns`

Skips generating GraphQL types whose name contains a configured substring, and the fields referencing them, plus a reachability prune for anything orphaned. In the application nothing queries `_stream` subscriptions or statistical aggregates (`stddev`/`var_pop`/`var_samp`/`variance`), which together are ~21% of all generated code.

```yaml
split_schema_modules: true
exclude_type_patterns:
  - _stddev
  - _var_pop
  - _var_samp
  - _variance
  - _stream_cursor
```

## Numbers (admin-dashboard, isolated package build, 18 cores)

| Scenario | before | after |
|---|---|---|
| Any schema change | 8.5s (whole module) | **1.1s** (typical: one chunk + dependents) |
| Comment-only chunk change | 8.5s | 1 module compiled, 37 skipped |
| Full package from scratch | 8.5s | 4.4s |
| No-change regen | rewrites every file | touches nothing |

Generated tree across all 26 roles: 275,928 → 217,379 lines with the exclusions above. The split also composes with purs's externs-diff cutoff: a real interface change to one table's bool_exp recompiled 12 modules and skipped 26.

## Verification

- Without the new flags, output is byte-identical to v0.1.28's (checked against the application's committed generated code).
- With flags on: all 26 role schemas + shared enums compile with **zero warnings**, and a real consumer compiles unchanged.
- Unit tests for the SCC/level algorithm and tokenizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)